### PR TITLE
Added doctest that shows we can ignore based pattern match for the module

### DIFF
--- a/lib/mix_unused/filter.ex
+++ b/lib/mix_unused/filter.ex
@@ -69,6 +69,18 @@ defmodule MixUnused.Filter do
   []
   ```
 
+  Allow pattern matching module as well:
+
+  ```
+  iex> functions = %{
+  ...>   {Foo, :bar, 1} => %{},
+  ...>   {Foo.Bar, :baz, 1} => %{}
+  ...> }
+  iex> patterns = [{~r/Foo\..*$/, ~r/^ba[rz]$/}]
+  iex> #{inspect(__MODULE__)}.reject_matching(functions, patterns)
+  [{{Foo, :bar, 1}, %{}}]
+  ```
+
   For arity you can pass range:
 
   ```


### PR DESCRIPTION
From the current documentation it's not clear that we can pattern match on the module name as well when ignoring exports. Added doctest to show that more clearly.