### PR TITLE
feat: add covertool support

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -32,4 +32,9 @@ jobs:
     - name: Install dependencies
       run: mix do deps.get, deps.compile
     - name: Run tests
-      run: mix test
+      run: mix test --cover
+    - name: Upload coverage results
+      run: |
+        curl -Os https://uploader.codecov.io/latest/linux/codecov
+        chmod +x codecov
+        ./codecov

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,8 @@ defmodule MixUnused.MixProject do
       deps: [
         {:credo, ">= 0.0.0", only: :dev, runtime: false},
         {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
-        {:dialyxir, "~> 1.0", only: :dev, runtime: false}
+        {:dialyxir, "~> 1.0", only: :dev, runtime: false},
+        {:covertool, "~> 2.0", only: :test}
       ],
       docs: [
         extras: [
@@ -33,7 +34,8 @@ defmodule MixUnused.MixProject do
         source_url: @source_url,
         source_url: "v#{@version}",
         formatters: ["html"]
-      ]
+      ],
+      test_coverage: [tool: :covertool]
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm", "7af5c7e09fe1d40f76c8e4f9dd2be7cebd83909f31fee7cd0e9eadc567da8353"},
+  "covertool": {:hex, :covertool, "2.0.4", "54acff6cddd88d28dea663cd2e1fe20dd32fcf5f5d3aff7d59031ce44ce39efa", [:rebar3], [], "hexpm", "5c9568ba4308fda2082172737c80c31d991ea83961eb10791f06106a870d0cdc"},
   "credo": {:hex, :credo, "1.5.6", "e04cc0fdc236fefbb578e0c04bd01a471081616e741d386909e527ac146016c6", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:file_system, "~> 0.2.8", [hex: :file_system, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "4b52a3e558bd64e30de62a648518a5ea2b6e3e5d2b164ef5296244753fc7eb17"},
   "dialyxir": {:hex, :dialyxir, "1.1.0", "c5aab0d6e71e5522e77beff7ba9e08f8e02bad90dfbeffae60eaf0cb47e29488", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "07ea8e49c45f15264ebe6d5b93799d4dd56a44036cf42d0ad9c960bc266c0b9a"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.15", "b29e8e729f4aa4a00436580dcc2c9c5c51890613457c193cc8525c388ccb2f06", [:mix], [], "hexpm", "044523d6438ea19c1b8ec877ec221b008661d3c27e3b848f4c879f500421ca5c"},


### PR DESCRIPTION
The only rough edge is that `covertool` seems not to honour the `:output` option for `:test_coverage` and it always generates the `coverage.xml` file in the root path. It'd been nice to have it generated in `./cover` so it's already `.gitignore`d by default.

It's my first time modifying a Github action, so I'm not sure on how to test it.

Fixes #25