### PR TITLE
Add support for unary functions in filters

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,5 +1,6 @@
 # Used by "mix format"
 [
   line_length: 80,
+  import_deps: ~w[stream_data]a,
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -14,6 +14,9 @@ jobs:
       matrix:
         otp_version: ['24.0', '23.3', '22.3']
         elixir_version: ['1.10.3', '1.11.4', '1.12.1']
+        exclude:
+          - otp_version: '24.0'
+            elixir_version: '1.10.3'
     steps:
     - uses: actions/checkout@v2
     - name: Set up Elixir

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -35,6 +35,8 @@ jobs:
         path: deps
         key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
         restore-keys: ${{ runner.os }}-mix-
+    - name: Fetch dependencies
+      run: mix deps.get
     - name: Check formatting
       run: mix format --check-formatted
 

--- a/lib/mix_unused/exports.ex
+++ b/lib/mix_unused/exports.ex
@@ -1,18 +1,7 @@
 defmodule MixUnused.Exports do
   @moduledoc false
 
-  defmodule Meta do
-    @moduledoc false
-
-    @type t() :: %__MODULE__{
-            signature: String.t(),
-            file: String.t(),
-            line: non_neg_integer(),
-            doc_meta: map()
-          }
-
-    defstruct signature: nil, file: "nofile", line: 1, doc_meta: %{}
-  end
+  alias MixUnused.Meta
 
   @type t() :: %{mfa() => Meta.t()} | [{mfa(), Meta.t()}]
 

--- a/lib/mix_unused/filter.ex
+++ b/lib/mix_unused/filter.ex
@@ -45,8 +45,8 @@ defmodule MixUnused.Filter do
     match?(pmod, fmod) and match?(pname, fname) and arity_match?(parity, farity)
   end
 
-  # TODO: Allow `cb/2` to match against function metadata
   defp mfa_match?(cb, mfa, _meta) when is_function(cb, 1), do: cb.(mfa)
+  defp mfa_match?(cb, mfa, meta) when is_function(cb, 2), do: cb.(mfa, meta)
 
   defp match?(value, value), do: true
   defp match?(:_, _value), do: true

--- a/lib/mix_unused/filter.ex
+++ b/lib/mix_unused/filter.ex
@@ -4,6 +4,7 @@ defmodule MixUnused.Filter do
   import Kernel, except: [match?: 2]
 
   alias MixUnused.Exports
+  alias MixUnused.Meta
 
   @type module_pattern() :: module() | Regex.t() | :_
   @type function_pattern() :: atom() | Regex.t() | :_
@@ -40,7 +41,7 @@ defmodule MixUnused.Filter do
     |> Map.new()
   end
 
-  @spec mfa_match?(mfa(), pattern(), Exports.Meta.t()) :: boolean()
+  @spec mfa_match?(mfa(), pattern(), Meta.t()) :: boolean()
   defp mfa_match?({pmod, pname, parity}, {fmod, fname, farity}, _meta) do
     match?(pmod, fmod) and match?(pname, fname) and arity_match?(parity, farity)
   end

--- a/lib/mix_unused/meta.ex
+++ b/lib/mix_unused/meta.ex
@@ -1,0 +1,14 @@
+defmodule MixUnused.Meta do
+  @moduledoc """
+  Metadata of the functions
+  """
+
+  @type t() :: %__MODULE__{
+          signature: String.t(),
+          file: String.t(),
+          line: non_neg_integer(),
+          doc_meta: map()
+        }
+
+  defstruct signature: nil, file: "nofile", line: 1, doc_meta: %{}
+end

--- a/mix.exs
+++ b/mix.exs
@@ -23,6 +23,7 @@ defmodule MixUnused.MixProject do
         {:credo, ">= 0.0.0", only: :dev, runtime: false},
         {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
         {:dialyxir, "~> 1.0", only: :dev, runtime: false},
+        {:stream_data, ">= 0.0.0", only: [:test, :dev]},
         {:covertool, "~> 2.0", only: :test}
       ],
       docs: [

--- a/mix.lock
+++ b/mix.lock
@@ -13,4 +13,5 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.15.2", "dc72dfe17eb240552857465cc00cce390960d9a0c055c4ccd38b70629227e97c", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.1", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "fd23ae48d09b32eff49d4ced2b43c9f086d402ee4fd4fcb2d7fad97fa8823e75"},
   "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.1", "264fc6864936b59fedb3ceb89998c64e9bb91945faf1eb115d349b96913cc2ef", [:mix], [], "hexpm", "23c31d0ec38c97bf9adde35bc91bc8e1181ea5202881f48a192f4aa2d2cf4d59"},
+  "stream_data": {:hex, :stream_data, "0.5.0", "b27641e58941685c75b353577dc602c9d2c12292dd84babf506c2033cd97893e", [:mix], [], "hexpm", "012bd2eec069ada4db3411f9115ccafa38540a3c78c4c0349f151fc761b9e271"},
 }

--- a/test/mix_unused/analyzers/private_test.exs
+++ b/test/mix_unused/analyzers/private_test.exs
@@ -1,7 +1,7 @@
 defmodule MixUnused.Analyzers.PrivateTest do
   use ExUnit.Case, async: true
 
-  alias MixUnused.Exports.Meta
+  alias MixUnused.Meta
 
   @subject MixUnused.Analyzers.Private
 

--- a/test/mix_unused/analyzers/recursive_only_test.exs
+++ b/test/mix_unused/analyzers/recursive_only_test.exs
@@ -1,7 +1,7 @@
 defmodule MixUnused.Analyzers.RecursiveOnlyTest do
   use ExUnit.Case, async: true
 
-  alias MixUnused.Exports.Meta
+  alias MixUnused.Meta
 
   @subject MixUnused.Analyzers.RecursiveOnly
 

--- a/test/mix_unused/analyzers/unused_test.exs
+++ b/test/mix_unused/analyzers/unused_test.exs
@@ -1,7 +1,7 @@
 defmodule MixUnused.Analyzers.UnusedTest do
   use ExUnit.Case, async: true
 
-  alias MixUnused.Exports.Meta
+  alias MixUnused.Meta
 
   @subject MixUnused.Analyzers.Unused
 

--- a/test/mix_unused/filter_test.exs
+++ b/test/mix_unused/filter_test.exs
@@ -1,7 +1,137 @@
 defmodule MixUnused.FilterTest do
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   @subject MixUnused.Filter
 
   doctest @subject
+
+  def func_name do
+    gen(
+      all str <- string([?a..?z, ?A..?Z, ?0..?9, ?_], max_length: 254),
+          last <- string([??, ?!], max_length: 1),
+          first <- string([?a..?z]),
+          do: String.to_atom(first <> str <> last)
+    )
+  end
+
+  def mfa do
+    gen(
+      all module <- atom(:alias),
+          function <- func_name(),
+          arity <- integer(0..255),
+          module != :_,
+          function != :_,
+          do: {module, function, arity}
+    )
+  end
+
+  def mfa_pattern({m, f, a}) do
+    gen(
+      all module <- frequency([{1, constant(:_)}, {9, constant(m)}]),
+          function <- frequency([{1, constant(:_)}, {9, constant(f)}]),
+          arity <- frequency([{1, constant(:_)}, {9, constant(a)}]),
+          do: {module, function, arity}
+    )
+  end
+
+  test "exact pattern" do
+    functions = %{
+      {Foo, :bar, 1} => %{},
+      {Bar, :baz, 2} => %{}
+    }
+
+    patterns = [{Foo, :bar, 1}]
+
+    assert @subject.reject_matching(functions, patterns) == %{
+             {Bar, :baz, 2} => %{}
+           }
+  end
+
+  @tag :slow
+  property "empty pattern list works as passthrough" do
+    check all functions <- map_of(mfa(), constant(%{})) do
+      assert functions == @subject.reject_matching(functions, [])
+    end
+  end
+
+  property "simple patterns" do
+    check all mfa <- mfa(),
+              pattern <- mfa_pattern(mfa) do
+      functions = %{mfa => %{}}
+
+      assert %{} == @subject.reject_matching(functions, [pattern])
+    end
+  end
+
+  property "reduced patterns" do
+    check all mfa <- mfa(),
+              {m, f, _} = mfa_pattern <- mfa_pattern(mfa),
+              pattern <-
+                one_of([
+                  constant(mfa_pattern),
+                  tuple({m, f}),
+                  tuple({m}),
+                  constant(m)
+                ]) do
+      functions = %{mfa => %{}}
+
+      assert %{} == @subject.reject_matching(functions, [pattern])
+    end
+  end
+
+  describe "regular expression" do
+    test "can be used for function name" do
+      functions = %{
+        {Foo, :bar, 1} => %{},
+        {Foo, :baz, 1} => %{}
+      }
+
+      patterns = [{Foo, ~r/^ba[rz]$/}]
+      assert @subject.reject_matching(functions, patterns) == %{}
+    end
+
+    test "can be used for module name" do
+      functions = %{
+        {Foo, :bar, 1} => %{},
+        {Foo, :baz, 1} => %{}
+      }
+
+      patterns = [{Foo, ~r/^ba[rz]$/}]
+      assert @subject.reject_matching(functions, patterns) == %{}
+    end
+  end
+
+  describe "range" do
+    test "arity can be checked against range" do
+      functions = %{
+        {Foo, :bar, 1} => %{},
+        {Foo, :bar, 2} => %{},
+        {Foo, :bar, 3} => %{}
+      }
+
+      patterns = [{Foo, :bar, 2..3}]
+
+      assert @subject.reject_matching(functions, patterns) == %{
+               {Foo, :bar, 1} => %{}
+             }
+    end
+  end
+
+  describe "predicate function" do
+    test "simple predicate" do
+      functions = %{
+        {Foo, :bar, 1} => %{},
+        {Foo, :bar, 2} => %{},
+        {Foo, :bar, 3} => %{}
+      }
+
+      patterns = [&match?({Foo, :bar, 2}, &1)]
+
+      assert @subject.reject_matching(functions, patterns) == %{
+               {Foo, :bar, 1} => %{},
+               {Foo, :bar, 3} => %{}
+             }
+    end
+  end
 end

--- a/test/mix_unused/filter_test.exs
+++ b/test/mix_unused/filter_test.exs
@@ -2,6 +2,8 @@ defmodule MixUnused.FilterTest do
   use ExUnit.Case, async: true
   use ExUnitProperties
 
+  alias MixUnused.Meta
+
   @subject MixUnused.Filter
 
   doctest @subject
@@ -50,7 +52,7 @@ defmodule MixUnused.FilterTest do
 
   @tag :slow
   property "empty pattern list works as passthrough" do
-    check all functions <- map_of(mfa(), constant(%{})) do
+    check all functions <- map_of(mfa(), constant(%Meta{})) do
       assert functions == @subject.reject_matching(functions, [])
     end
   end
@@ -99,6 +101,24 @@ defmodule MixUnused.FilterTest do
 
       patterns = [{Foo, ~r/^ba[rz]$/}]
       assert @subject.reject_matching(functions, patterns) == %{}
+    end
+
+    test "raw regex matches module name" do
+      functions = %{
+        {Foo, :bar, 1} => %{},
+        {Boo, :bar, 1} => %{}
+      }
+
+      patterns = [~r/.oo/]
+      assert @subject.reject_matching(functions, patterns) == %{}
+
+      functions = %{
+        {Foo, :far, 1} => %{},
+        {Boo, :bar, 1} => %{}
+      }
+
+      patterns = [~r/.ar/]
+      refute @subject.reject_matching(functions, patterns) == %{}
     end
   end
 

--- a/test/mix_unused/tracer_test.exs
+++ b/test/mix_unused/tracer_test.exs
@@ -1,5 +1,5 @@
 defmodule MixUnused.TracerTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
 
   @subject MixUnused.Tracer
 


### PR DESCRIPTION
Predicate functions take `mfa()` tuple and return boolean whether the given function should be ignored.

Close #29
Close #31 