### PR TITLE
Fix false positives by marking subtree as called

### DIFF
--- a/test/fixtures/cycle/lib/bar.ex
+++ b/test/fixtures/cycle/lib/bar.ex
@@ -1,0 +1,13 @@
+defmodule Bar do
+  def foo do
+    Baz.foo()
+  end
+
+  def bar do
+    "bar"
+  end
+
+  def baz do
+    Baz.baz()
+  end
+end

--- a/test/fixtures/cycle/lib/baz.ex
+++ b/test/fixtures/cycle/lib/baz.ex
@@ -1,0 +1,13 @@
+defmodule Baz do
+  def foo do
+    Foo.foo()
+  end
+
+  def bar do
+    Foo.bar()
+  end
+
+  def baz do
+    "baz"
+  end
+end

--- a/test/fixtures/cycle/lib/foo.ex
+++ b/test/fixtures/cycle/lib/foo.ex
@@ -1,0 +1,13 @@
+defmodule Foo do
+  def foo do
+    "foo"
+  end
+
+  def bar do
+    Bar.bar()
+  end
+
+  def baz do
+    Bar.baz()
+  end
+end

--- a/test/fixtures/cycle/mix.exs
+++ b/test/fixtures/cycle/mix.exs
@@ -1,0 +1,18 @@
+defmodule MixUnused.Fixtures.UnleanProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :cycle,
+      compilers: [:unused | Mix.compilers()],
+      version: "0.0.0",
+      unused: [
+        ignore: [
+          {Foo, ~r/^(baz)$/},
+          {Bar, ~r/^(foo)$/},
+          {Baz, ~r/^(bar)$/}
+        ]
+      ]
+    ]
+  end
+end

--- a/test/mix/tasks/compile.unused_test.exs
+++ b/test/mix/tasks/compile.unused_test.exs
@@ -193,6 +193,20 @@ defmodule Mix.Tasks.Compile.UnusedTest do
     end
   end
 
+  describe "cycle" do
+    test "unused function is reported" do
+      in_fixture("cycle", fn ->
+        assert {{:ok, diagnostics}, output} = run(:cycle, "compile")
+        refute output =~ "Foo.foo/0 is unused"
+        refute output =~ "Bar.bar/0 is unused"
+        refute output =~ "Baz.baz/0 is unused"
+        refute find_diagnostics_for(diagnostics, {Foo, :foo, 0}, Unused)
+        refute find_diagnostics_for(diagnostics, {Bar, :bar, 0}, Unused)
+        refute find_diagnostics_for(diagnostics, {Baz, :baz, 0}, Unused)
+      end)
+    end
+  end
+
   defp run(project, task, args \\ []) do
     Mix.Project.in_project(project, ".", fn _ ->
       captured =


### PR DESCRIPTION
Fixes #39.

The current algorithm for marking functions as unused will only work if all functions are processed in a certain order. When that doesn't happen then some used functions will actually get marked as unused. For example, with functions `A -> B -> C` if `B` gets processed before `A` then we'll never know that `B` is actually used.

The fix is to recursively mark all called functions as called. Since we already have a graph, when we mark one function as called we can fetch a list of all functions it calls with [Graph.out_neighbors](https://hexdocs.pm/libgraph/Graph.html#out_neighbors/2) and mark them as called too.

Sorry for the lack of tests. I'm not sure what the exact conditions are that trigger this problem.

In my project with thousands of modules, this reduced the number of unused methods being reported by 23% from 1860 to 1428.