### PR TITLE
Allow for specifying checks in mix config

### DIFF
--- a/lib/mix_unused/config.ex
+++ b/lib/mix_unused/config.ex
@@ -25,6 +25,7 @@ defmodule MixUnused.Config do
 
   defp extract_config(%__MODULE__{} = config, mix_config) do
     config
+    |> maybe_set(:checks, mix_config[:checks])
     |> maybe_set(:ignore, mix_config[:ignore])
     |> maybe_set(:severity, mix_config[:severity])
     |> maybe_set(:warnings_as_errors, mix_config[:warnings_as_errors])


### PR DESCRIPTION
Support using mix_unused without using all checks. For example, only the unused check.

```
unused: [
  checks: [MixUnused.Analyzers.Unused]
]
```