### PR TITLE
Address deprecation warnings

### DIFF
--- a/lib/mix_unused/filter.ex
+++ b/lib/mix_unused/filter.ex
@@ -58,6 +58,6 @@ defmodule MixUnused.Filter do
 
   defp arity_match?(:_, _value), do: true
   defp arity_match?(value, value), do: true
-  defp arity_match?(_.._ = range, value), do: value in range
+  defp arity_match?(_.._//_ = range, value), do: value in range
   defp arity_match?(_, _), do: false
 end

--- a/mix.exs
+++ b/mix.exs
@@ -11,6 +11,7 @@ defmodule MixUnused.MixProject do
       version: @version,
       elixir: "~> 1.10",
       elixirc_paths: elixirc_paths(Mix.env()),
+      env: [test: [warnings_as_errors: false]],
       package: [
         licenses: ~w[MIT],
         links: %{
@@ -24,7 +25,7 @@ defmodule MixUnused.MixProject do
         {:credo, ">= 0.0.0", only: :dev, runtime: false},
         {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
         {:dialyxir, "~> 1.0", only: :dev, runtime: false},
-        {:stream_data, ">= 0.0.0", only: [:test, :dev]},
+        {:stream_data, "~> 1.0", only: [:test, :dev]},
         {:covertool, "~> 2.0", only: :test}
       ],
       docs: [

--- a/mix.lock
+++ b/mix.lock
@@ -13,5 +13,5 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.16.1", "cc9e3ca312f1cfeccc572b37a09980287e243648108384b97ff2b76e505c3555", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.2.3 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "e127a341ad1b209bd80f7bd1620a15693a9908ed780c3b763bccf7d200c767c6"},
   "makeup_erlang": {:hex, :makeup_erlang, "0.1.3", "d684f4bac8690e70b06eb52dad65d26de2eefa44cd19d64a8095e1417df7c8fd", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "b78dc853d2e670ff6390b605d807263bf606da3c82be37f9d7f68635bd886fc9"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.0", "51f9b613ea62cfa97b25ccc2c1b4216e81df970acd8e16e8d1bdc58fef21370d", [:mix], [], "hexpm", "9c565862810fb383e9838c1dd2d7d2c437b3d13b267414ba6af33e50d2d1cf28"},
-  "stream_data": {:hex, :stream_data, "0.6.0", "e87a9a79d7ec23d10ff83eb025141ef4915eeb09d4491f79e52f2562b73e5f47", [:mix], [], "hexpm", "b92b5031b650ca480ced047578f1d57ea6dd563f5b57464ad274718c9c29501c"},
+  "stream_data": {:hex, :stream_data, "1.1.3", "15fdb14c64e84437901258bb56fc7d80aaf6ceaf85b9324f359e219241353bfb", [:mix], [], "hexpm", "859eb2be72d74be26c1c4f272905667672a52e44f743839c57c7ee73a1a66420"},
 }

--- a/test/mix_unused/tracer_test.exs
+++ b/test/mix_unused/tracer_test.exs
@@ -31,7 +31,6 @@ defmodule MixUnused.TracerTest do
           end
 
         Code.put_compiler_option(:tracers, [@subject])
-        Code.put_compiler_option(:warnings_as_errors, false)
         Code.put_compiler_option(:ignore_module_conflict, true)
         Code.put_compiler_option(:ignore_already_consolidated, true)
         Code.put_compiler_option(:no_warn_undefined, :all)

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -58,11 +58,10 @@ defmodule MixUnused.Case do
     options = Code.compiler_options()
 
     try do
-      Code.put_compiler_option(:warnings_as_errors, false)
       Code.put_compiler_option(:ignore_module_conflict, true)
       Code.put_compiler_option(:ignore_already_consolidated, true)
 
-      run_task("compile", opts)
+      run_task("compile", [warnings_as_errors: false] ++ opts)
     after
       Code.compiler_options(options)
     end


### PR DESCRIPTION
There are several deprecation warnings when running `mix test`, and this PR addresses those warnings. Specifically:
* Stop using `_.._` and instead use `_.._//_`, which addresses the warning: `min..max inside match is deprecated, you must always match on the step: min..max//var or min..max//_ if you want to ignore it`
* Upgrade `stream_data` dep, which causes several warnings of the form:  `ExUnit.Case.register_test/4 is deprecated. Use register_test/6 instead`.
* Stop using `Code.put_compiler_option(:warnings_as_errors, false)` in order to address `:warnings_as_errors is deprecated as part of Code.put_compiler_option/2, pass it as option to Kernel.ParallelCompiler instead`.